### PR TITLE
feat: add -timeline flag for horizontal bar schedule display

### DIFF
--- a/main.go
+++ b/main.go
@@ -510,11 +510,11 @@ func main() {
 	credentialsFile := filepath.Join(confDir, programName, "credentials.json")
 	formatStr := ""
 	dateStr := ""
-	timelineMode := false
+	timelineRange := ""
 	flag.StringVar(&credentialsFile, "credentials", credentialsFile, "`path` to credentials.json")
 	flag.StringVar(&formatStr, "format", "", "Go template for event output (non-interactive mode)")
 	flag.StringVar(&dateStr, "date", "", "Date to show (YYYY-mm-dd or +1d/-1d)")
-	flag.BoolVar(&timelineMode, "timeline", false, "Print daily schedule as timeline and exit")
+	flag.StringVar(&timelineRange, "timeline", "", "Print daily schedule as timeline (`auto` or `HH-HH`, e.g. 09-18)")
 	flag.Parse()
 
 	b, err := os.ReadFile(credentialsFile)
@@ -543,8 +543,8 @@ func main() {
 		log.Fatalf("invalid --date: %v", err)
 	}
 
-	if timelineMode {
-		err := printEventsTimeline(showDate)
+	if timelineRange != "" {
+		err := printEventsTimeline(showDate, timelineRange)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -466,6 +466,27 @@ func (e *eventItem) String() string {
 	)
 }
 
+// timelineFlag can be used as -timeline (bool, defaults to "auto")
+// or -timeline 09-18 (with a value).
+type timelineFlag struct {
+	set   bool
+	value string
+}
+
+func (f *timelineFlag) String() string { return f.value }
+
+func (f *timelineFlag) Set(val string) error {
+	f.set = true
+	if val == "true" || val == "" {
+		f.value = "auto"
+	} else {
+		f.value = val
+	}
+	return nil
+}
+
+func (f *timelineFlag) IsBoolFlag() bool { return true }
+
 var oauthClient *http.Client
 
 func parseDateArg(arg string, base time.Time) (time.Time, error) {
@@ -510,11 +531,11 @@ func main() {
 	credentialsFile := filepath.Join(confDir, programName, "credentials.json")
 	formatStr := ""
 	dateStr := ""
-	timelineRange := ""
+	var timeline timelineFlag
 	flag.StringVar(&credentialsFile, "credentials", credentialsFile, "`path` to credentials.json")
 	flag.StringVar(&formatStr, "format", "", "Go template for event output (non-interactive mode)")
 	flag.StringVar(&dateStr, "date", "", "Date to show (YYYY-mm-dd or +1d/-1d)")
-	flag.StringVar(&timelineRange, "timeline", "", "Print daily schedule as timeline (`auto` or `HH-HH`, e.g. 09-18)")
+	flag.Var(&timeline, "timeline", "Print daily schedule as timeline (or specify `HH-HH` range, e.g. 09-18)")
 	flag.Parse()
 
 	b, err := os.ReadFile(credentialsFile)
@@ -543,8 +564,8 @@ func main() {
 		log.Fatalf("invalid --date: %v", err)
 	}
 
-	if timelineRange != "" {
-		err := printEventsTimeline(showDate, timelineRange)
+	if timeline.set {
+		err := printEventsTimeline(showDate, timeline.value)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -510,9 +510,11 @@ func main() {
 	credentialsFile := filepath.Join(confDir, programName, "credentials.json")
 	formatStr := ""
 	dateStr := ""
+	timelineMode := false
 	flag.StringVar(&credentialsFile, "credentials", credentialsFile, "`path` to credentials.json")
 	flag.StringVar(&formatStr, "format", "", "Go template for event output (non-interactive mode)")
 	flag.StringVar(&dateStr, "date", "", "Date to show (YYYY-mm-dd or +1d/-1d)")
+	flag.BoolVar(&timelineMode, "timeline", false, "Print daily schedule as timeline and exit")
 	flag.Parse()
 
 	b, err := os.ReadFile(credentialsFile)
@@ -539,6 +541,14 @@ func main() {
 	showDate, err := parseDateArg(dateStr, base)
 	if err != nil {
 		log.Fatalf("invalid --date: %v", err)
+	}
+
+	if timelineMode {
+		err := printEventsTimeline(showDate)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
 	}
 
 	if formatStr != "" {

--- a/timeline.go
+++ b/timeline.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"golang.org/x/term"
+)
+
+var (
+	timelineBarStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#50CFFA"))
+	timelineConflictStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#AD3252"))
+	timelineDeclinedStyle = lipgloss.NewStyle().Strikethrough(true).Foreground(lipgloss.Color("#777777"))
+	timelineAcceptedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#2EAD71"))
+	timelineDimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#555555"))
+)
+
+func printEventsTimeline(date time.Time) error {
+	events, err := fetchEventsForDate(date)
+	if err != nil {
+		return err
+	}
+
+	weekday := jaWeekday(date.Weekday())
+
+	if len(events) == 0 {
+		fmt.Printf("%s (%s)\n\n  予定はありません\n", date.Format("2006-01-02"), weekday)
+		return nil
+	}
+
+	// Determine time range
+	minTime, maxTime := timeRange(events)
+
+	// Terminal width
+	termWidth := 80
+	if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && w > 0 {
+		termWidth = w
+	}
+
+	// Name column width: max event name width, capped
+	const maxNameWidth = 20
+	nameWidth := 0
+	for _, ev := range events {
+		w := runewidth.StringWidth(ev.Summary)
+		if w > nameWidth {
+			nameWidth = w
+		}
+	}
+	if nameWidth > maxNameWidth {
+		nameWidth = maxNameWidth
+	}
+	if nameWidth < 4 {
+		nameWidth = 4
+	}
+
+	// Time label column width: "  10:00-11:00  ⚡" => ~18
+	const timeLabelWidth = 18
+
+	// Bar width = remaining
+	barWidth := termWidth - nameWidth - 2 - timeLabelWidth // 2 for spacing around bar
+	if barWidth < 10 {
+		barWidth = 10
+	}
+
+	// Print header
+	fmt.Printf("%s (%s)\n\n", date.Format("2006-01-02"), weekday)
+
+	// Print time axis header
+	printTimeAxis(nameWidth, barWidth, minTime, maxTime)
+
+	// Print each event
+	for _, ev := range events {
+		printEventBar(ev, nameWidth, barWidth, minTime, maxTime)
+	}
+
+	return nil
+}
+
+func jaWeekday(w time.Weekday) string {
+	names := [...]string{"日", "月", "火", "水", "木", "金", "土"}
+	return names[w]
+}
+
+func timeRange(events []*eventItem) (minTime, maxTime time.Time) {
+	minTime = events[0].Start
+	maxTime = events[0].End
+
+	for _, ev := range events {
+		if ev.Start.Before(minTime) {
+			minTime = ev.Start
+		}
+		if ev.End.After(maxTime) {
+			maxTime = ev.End
+		}
+	}
+
+	// Round down to hour for minTime, round up for maxTime
+	minTime = minTime.Truncate(time.Hour)
+	if maxTime.Truncate(time.Hour) != maxTime {
+		maxTime = maxTime.Truncate(time.Hour).Add(time.Hour)
+	}
+
+	// Ensure at least 1 hour range
+	if !maxTime.After(minTime) {
+		maxTime = minTime.Add(time.Hour)
+	}
+
+	return
+}
+
+func timeToPos(t, minTime, maxTime time.Time, barWidth int) int {
+	total := maxTime.Sub(minTime).Seconds()
+	if total == 0 {
+		return 0
+	}
+	elapsed := t.Sub(minTime).Seconds()
+	pos := int(math.Round(elapsed / total * float64(barWidth)))
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > barWidth {
+		pos = barWidth
+	}
+	return pos
+}
+
+func printTimeAxis(nameWidth, barWidth int, minTime, maxTime time.Time) {
+	// Build label and tick lines as rune slices for proper positioning
+	labelSlots := make([]byte, barWidth)
+	for i := range labelSlots {
+		labelSlots[i] = ' '
+	}
+
+	tickRunes := make([]string, barWidth)
+	for i := range tickRunes {
+		tickRunes[i] = " "
+	}
+
+	t := minTime
+	for !t.After(maxTime) {
+		pos := timeToPos(t, minTime, maxTime, barWidth)
+		label := t.Format("15")
+
+		if pos < barWidth {
+			tickRunes[pos] = "╵"
+		}
+
+		// Place label so it starts at pos (left-aligned from tick)
+		for i := 0; i < len(label); i++ {
+			p := pos + i
+			if p >= 0 && p < barWidth {
+				labelSlots[p] = label[i]
+			}
+		}
+
+		t = t.Add(time.Hour)
+	}
+
+	padding := strings.Repeat(" ", nameWidth+2)
+	fmt.Printf("%s%s\n", padding, string(labelSlots))
+	fmt.Printf("%s%s\n", padding, strings.Join(tickRunes, ""))
+}
+
+func printEventBar(ev *eventItem, nameWidth, barWidth int, minTime, maxTime time.Time) {
+	// Truncate or pad event name
+	name := truncateString(ev.Summary, nameWidth)
+	pad := nameWidth - runewidth.StringWidth(name)
+	if pad < 0 {
+		pad = 0
+	}
+	namePadded := name + strings.Repeat(" ", pad)
+
+	// Calculate bar positions
+	startPos := timeToPos(ev.Start, minTime, maxTime, barWidth)
+	endPos := timeToPos(ev.End, minTime, maxTime, barWidth)
+
+	// For instant/very short events
+	isShort := endPos-startPos < 2
+	if endPos <= startPos {
+		endPos = startPos + 1
+	}
+
+	// Build bar
+	bar := make([]string, barWidth)
+	for i := range bar {
+		bar[i] = "─"
+	}
+
+	// Place event block
+	if isShort {
+		if startPos > 0 {
+			bar[startPos-1] = "┨"
+		}
+		if startPos < barWidth {
+			bar[startPos] = "░"
+		}
+		if startPos+1 < barWidth {
+			bar[startPos+1] = "┠"
+		}
+	} else {
+		if startPos > 0 {
+			bar[startPos-1] = "┨"
+		}
+		for i := startPos; i < endPos && i < barWidth; i++ {
+			bar[i] = "█"
+		}
+		if endPos < barWidth {
+			bar[endPos] = "┠"
+		}
+	}
+
+	// Edge markers
+	if bar[0] == "─" {
+		bar[0] = "╶"
+	}
+	if bar[barWidth-1] == "─" {
+		bar[barWidth-1] = "╴"
+	}
+
+	barStr := strings.Join(bar, "")
+
+	// Time label
+	var timeLabel string
+	if ev.Start.Equal(ev.End) || isShort {
+		timeLabel = ev.Start.Format("15:04")
+	} else {
+		timeLabel = ev.Start.Format("15:04") + "-" + ev.End.Format("15:04")
+	}
+
+	// Conflict marker
+	conflictMark := ""
+	if len(ev.ConflictsWith) > 0 {
+		conflictMark = "  ⚡"
+	}
+
+	// Style the output
+	var nameStyled, barStyled, timeLabelStyled string
+
+	if ev.Declined() {
+		nameStyled = timelineDeclinedStyle.Render(namePadded)
+		barStyled = timelineDimStyle.Render(barStr)
+		timeLabelStyled = timelineDeclinedStyle.Render(timeLabel)
+	} else if len(ev.ConflictsWith) > 0 {
+		nameStyled = timelineConflictStyle.Render(namePadded)
+		barStyled = timelineConflictStyle.Render(barStr)
+		timeLabelStyled = timelineConflictStyle.Render(timeLabel + conflictMark)
+	} else if ev.Accepted() {
+		nameStyled = timelineAcceptedStyle.Render(namePadded)
+		barStyled = timelineAcceptedStyle.Render(barStr)
+		timeLabelStyled = timelineAcceptedStyle.Render(timeLabel)
+	} else {
+		nameStyled = timelineBarStyle.Render(namePadded)
+		barStyled = timelineBarStyle.Render(barStr)
+		timeLabelStyled = timelineBarStyle.Render(timeLabel)
+	}
+
+	fmt.Printf(" %s  %s  %s\n", nameStyled, barStyled, timeLabelStyled)
+}
+
+func truncateString(s string, maxWidth int) string {
+	w := runewidth.StringWidth(s)
+	if w <= maxWidth {
+		return s
+	}
+
+	ellipsis := "…"
+	ellipsisWidth := runewidth.StringWidth(ellipsis)
+
+	result := ""
+	currentWidth := 0
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if currentWidth+rw > maxWidth-ellipsisWidth {
+			break
+		}
+		result += string(r)
+		currentWidth += rw
+	}
+	return result + ellipsis
+}

--- a/timeline.go
+++ b/timeline.go
@@ -268,18 +268,15 @@ func truncateString(s string, maxWidth int) string {
 		return s
 	}
 
-	ellipsis := "…"
-	ellipsisWidth := runewidth.StringWidth(ellipsis)
-
 	result := ""
 	currentWidth := 0
 	for _, r := range s {
 		rw := runewidth.RuneWidth(r)
-		if currentWidth+rw > maxWidth-ellipsisWidth {
+		if currentWidth+rw > maxWidth-2 { // 2 for ".."
 			break
 		}
 		result += string(r)
 		currentWidth += rw
 	}
-	return result + ellipsis
+	return result + ".."
 }

--- a/timeline.go
+++ b/timeline.go
@@ -246,9 +246,9 @@ func printEventBar(ev *eventItem, nameWidth, barWidth int, minTime, maxTime time
 
 	barStr := strings.Join(bar, "")
 
-	// Time label
+	// Time label (based on actual duration, not display width)
 	var timeLabel string
-	if ev.Start.Equal(ev.End) || isShort {
+	if ev.Start.Equal(ev.End) {
 		timeLabel = ev.Start.Format("15:04")
 	} else {
 		timeLabel = ev.Start.Format("15:04") + "-" + ev.End.Format("15:04")

--- a/timeline.go
+++ b/timeline.go
@@ -58,11 +58,11 @@ func printEventsTimeline(date time.Time) error {
 		nameWidth = 4
 	}
 
-	// Time label column width: "  10:00-11:00  ⚡" => ~18
-	const timeLabelWidth = 18
+	// Time label column width: "  10:00-11:00" => ~15
+	const timeLabelWidth = 15
 
-	// Bar width = remaining
-	barWidth := termWidth - nameWidth - 2 - timeLabelWidth // 2 for spacing around bar
+	// Bar width = remaining (1 for conflict mark, 2 for spacing around bar)
+	barWidth := termWidth - 1 - nameWidth - 2 - timeLabelWidth
 	if barWidth < 10 {
 		barWidth = 10
 	}
@@ -161,7 +161,7 @@ func printTimeAxis(nameWidth, barWidth int, minTime, maxTime time.Time) {
 		t = t.Add(time.Hour)
 	}
 
-	padding := strings.Repeat(" ", nameWidth+2)
+	padding := strings.Repeat(" ", nameWidth+3) // 1(conflict mark) + nameWidth + 2(spacing)
 	fmt.Printf("%s%s\n", padding, string(labelSlots))
 	fmt.Printf("%s%s\n", padding, strings.Join(tickRunes, ""))
 }
@@ -232,10 +232,10 @@ func printEventBar(ev *eventItem, nameWidth, barWidth int, minTime, maxTime time
 		timeLabel = ev.Start.Format("15:04") + "-" + ev.End.Format("15:04")
 	}
 
-	// Conflict marker
-	conflictMark := ""
-	if len(ev.ConflictsWith) > 0 {
-		conflictMark = "  ⚡"
+	// Conflict marker (left side)
+	conflictMark := " "
+	if len(ev.ConflictsWith) > 0 && !ev.Declined() {
+		conflictMark = timelineConflictStyle.Render("!")
 	}
 
 	// Style the output
@@ -248,7 +248,7 @@ func printEventBar(ev *eventItem, nameWidth, barWidth int, minTime, maxTime time
 	} else if len(ev.ConflictsWith) > 0 {
 		nameStyled = timelineConflictStyle.Render(namePadded)
 		barStyled = timelineConflictStyle.Render(barStr)
-		timeLabelStyled = timelineConflictStyle.Render(timeLabel + conflictMark)
+		timeLabelStyled = timelineConflictStyle.Render(timeLabel)
 	} else if ev.Accepted() {
 		nameStyled = timelineAcceptedStyle.Render(namePadded)
 		barStyled = timelineAcceptedStyle.Render(barStr)
@@ -259,7 +259,7 @@ func printEventBar(ev *eventItem, nameWidth, barWidth int, minTime, maxTime time
 		timeLabelStyled = timelineBarStyle.Render(timeLabel)
 	}
 
-	fmt.Printf(" %s  %s  %s\n", nameStyled, barStyled, timeLabelStyled)
+	fmt.Printf("%s%s  %s  %s\n", conflictMark, nameStyled, barStyled, timeLabelStyled)
 }
 
 func truncateString(s string, maxWidth int) string {

--- a/timeline.go
+++ b/timeline.go
@@ -20,7 +20,7 @@ var (
 	timelineDimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("#555555"))
 )
 
-func printEventsTimeline(date time.Time) error {
+func printEventsTimeline(date time.Time, rangeSpec string) error {
 	events, err := fetchEventsForDate(date)
 	if err != nil {
 		return err
@@ -34,7 +34,10 @@ func printEventsTimeline(date time.Time) error {
 	}
 
 	// Determine time range
-	minTime, maxTime := timeRange(events)
+	minTime, maxTime, err := resolveTimeRange(date, events, rangeSpec)
+	if err != nil {
+		return err
+	}
 
 	// Terminal width
 	termWidth := 80
@@ -86,7 +89,25 @@ func jaWeekday(w time.Weekday) string {
 	return names[w]
 }
 
-func timeRange(events []*eventItem) (minTime, maxTime time.Time) {
+// resolveTimeRange determines the display time range for the timeline.
+// rangeSpec is "auto" (auto-detect with 30min margin) or "HH-HH" (e.g. "09-18").
+func resolveTimeRange(date time.Time, events []*eventItem, rangeSpec string) (minTime, maxTime time.Time, err error) {
+	if rangeSpec != "auto" {
+		var fromHour, toHour int
+		if _, err := fmt.Sscanf(rangeSpec, "%d-%d", &fromHour, &toHour); err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid timeline range %q: expected \"auto\" or \"HH-HH\" (e.g. 09-18)", rangeSpec)
+		}
+		if fromHour < 0 || fromHour > 23 || toHour < 0 || toHour > 24 || fromHour >= toHour {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid timeline range %q: hours must satisfy 0 <= from < to <= 24", rangeSpec)
+		}
+		loc := date.Location()
+		y, m, d := date.Date()
+		minTime = time.Date(y, m, d, fromHour, 0, 0, 0, loc)
+		maxTime = time.Date(y, m, d, toHour, 0, 0, 0, loc)
+		return minTime, maxTime, nil
+	}
+
+	// Auto: derive from events with 30min margin, rounded to hour
 	minTime = events[0].Start
 	maxTime = events[0].End
 
@@ -99,8 +120,9 @@ func timeRange(events []*eventItem) (minTime, maxTime time.Time) {
 		}
 	}
 
-	// Round down to hour for minTime, round up for maxTime
-	minTime = minTime.Truncate(time.Hour)
+	// Add 30min margin, then round to hour boundaries
+	minTime = minTime.Add(-30 * time.Minute).Truncate(time.Hour)
+	maxTime = maxTime.Add(30 * time.Minute)
 	if maxTime.Truncate(time.Hour) != maxTime {
 		maxTime = maxTime.Truncate(time.Hour).Add(time.Hour)
 	}
@@ -110,7 +132,7 @@ func timeRange(events []*eventItem) (minTime, maxTime time.Time) {
 		maxTime = minTime.Add(time.Hour)
 	}
 
-	return
+	return minTime, maxTime, nil
 }
 
 func timeToPos(t, minTime, maxTime time.Time, barWidth int) int {


### PR DESCRIPTION
## Summary
- 1日の予定を横型ガントチャート風にターミナル出力する `-timeline` フラグを追加
- `-timeline` 単独で自動範囲（予定の前後30分マージン）、`-timeline=HH-HH` で時間範囲を明示指定可能
- lipgloss による色付け（accepted=緑、declined=灰色+取消線、コンフリクト=赤+左端 `!` マーカー）
- ターミナル幅に応じたスケーリング

## Usage
```bash
gcal-tui -timeline              # 自動範囲
gcal-tui -timeline=09-18        # 9時〜18時
gcal-tui -timeline -date +1d    # 明日の予定
```

## Test plan
- [ ] 予定のある日で重複が正しく表示されるか確認
- [ ] 予定のない日で空表示が適切か確認
- [ ] `-timeline=HH-HH` で範囲が正しく反映されるか確認
- [ ] ターミナル幅を狭くした場合の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)